### PR TITLE
Allow setting agent_hostname to a custom value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [unreleased]
+
+### Added
+
+- `thinlinc_agent_hostname`, a variable that allows you to customize
+  /vsmagent/agent_hostname parameter on ThinLinc Agent servers.
+
+## [1.0] - 2018-11-22
+
+First release.
+
+### Added
+
+- An Ansible role to install the ThinLinc server software.
+
+[unreleased]: https://github.com/cendio/ansible-role-thinlinc-server/compare/v1.0...HEAD
+[1.0]: https://github.com/cendio/ansible-role-thinlinc-server/compare/...v1.0

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ thinlinc_webadm_password: "$6$7cc31a35e02e55ec$hm.1MsloeBJqNKljx9RH88Z/eRKZCka5Z
 ThinLinc Web Administration password. This default password is
 "thinlinc". Generate new hashes with `/opt/thinlinc/sbin/tl-gen-auth`.
 
+```yaml
+thinlinc_agent_hostname: null
+```
+
+This allows you to modify the hostname reported by the agent server to
+the client on connecting. See [ThinLinc in a NAT/Split-DNS
+Environment](https://www.cendio.com/resources/docs/tag/network.html#network_nat)
+for details. 
+
+Setting `thinlinc_agent_hostname` to null sets this parameter to `ansible_fqdn`.
+
 
 Examples
 --------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,12 @@ thinlinc_webadm_password: "$6$7cc31a35e02e55ec$hm.1MsloeBJqNKljx9RH88Z/eRKZCka5Z
 #  - new: overwrite all local changes with new defaults
 #  - parameters: auto-migrate old to new configuration
 thinlinc_tlsetup_migrate_conf: "old"
+
+
+# The agent hostname to report to clients. If your server is behind a
+# firewall with NAT, this must be set to an address that forwards to
+# your server. See
+# https://www.cendio.com/resources/docs/tag/network.html#network_nat
+#
+# The default value is null, which is equal to ansible_fqdn.
+thinlinc_agent_hostname: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
 - name: Configure /vsmagent/agent_hostname
   tlconfig:
     param: /vsmagent/agent_hostname
-    value: "{{ ansible_fqdn }}"
+    value: "{{ thinlinc_agent_hostname or ansible_fqdn }}"
   notify: restart vsmagent
   when: "'thinlinc-agents' in group_names"
 


### PR DESCRIPTION
Hindsight shows that always setting `agent_hostname` to `ansible_fqdn` wasn't as trouble-free as I had hoped. This PR introduces a new variable to let users set agent_hostname to whatever they feel like.

This PR also adds a ChangeLog which mentions this change.