### PR TITLE
Dash to underscore in inventory/hosts files

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,17 +102,17 @@ thinlinc-servers. Here's an example inventory file with one master
 server and three agent servers:
 
 ```yaml
-[thinlinc-masters]
+[thinlinc_masters]
 tl-master-01.example.com
 
-[thinlinc-agents]
+[thinlinc_agents]
 tl-agent-01.example.com
 tl-agent-02.example.com
 tl-agent-03.example.com
 
-[thinlinc-servers:children]
-thinlinc-masters
-thinlinc-agents
+[thinlinc_servers:children]
+thinlinc_masters
+thinlinc_agents
 ```
 
 Now that we got both a role and an inventory, connect the dots by

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ requirements.yml` to install the role:
   version: v1.1
 ```
 
-The role uses three groups - thinlinc-masters, thinlinc-agents and
+The role uses three groups - thinlinc_masters, thinlinc_agents and
 thinlinc-servers. Here's an example inventory file with one master
 server and three agent servers:
 
@@ -116,11 +116,11 @@ thinlinc_agents
 ```
 
 Now that we got both a role and an inventory, connect the dots by
-applying the thinlinc-server role to the thinlinc-servers group with a
+applying the thinlinc-server role to the thinlinc_servers group with a
 `thinlinc.yml` playbook:
 
 ```yaml
-- hosts: thinlinc-servers
+- hosts: thinlinc_servers
   roles:
     - { role: thinlinc-server, thinlinc_accept_eula: "yes" }
 ```

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,25 +45,25 @@
     param: /vsmagent/agent_hostname
     value: "{{ thinlinc_agent_hostname or ansible_fqdn }}"
   notify: restart vsmagent
-  when: "'thinlinc-agents' in group_names"
+  when: "'thinlinc_agents' in group_names"
 
 - name: Configure /vsmagent/master_hostname
   tlconfig:
     param: /vsmagent/master_hostname
-    value: "{{ groups['thinlinc-masters'][0] or 'localhost' }}"
+    value: "{{ groups['thinlinc_masters'][0] or 'localhost' }}"
   notify: restart vsmagent
-  when: "'thinlinc-agents' in group_names"
+  when: "'thinlinc_agents' in group_names"
 
 - name: Configure /vsmagent/allowed_clients
   tlconfig:
     param: /vsmagent/allowed_clients
-    value: "{{ ' '.join(groups['thinlinc-masters']) or 'localhost' }}"
+    value: "{{ ' '.join(groups['thinlinc_masters']) or 'localhost' }}"
   notify: restart vsmagent
-  when: "'thinlinc-agents' in group_names"
+  when: "'thinlinc_agents' in group_names"
 
 - name: Configure list of agent servers
   tlconfig:
     param: /vsmserver/subclusters/Default/agents
-    value: "{{ ' '.join(groups['thinlinc-agents']) or 'localhost' }}"
+    value: "{{ ' '.join(groups['thinlinc_agents']) or 'localhost' }}"
   notify: restart vsmserver
-  when: "'thinlinc-masters' in group_names"
+  when: "'thinlinc_masters' in group_names"

--- a/templates/thinlinc-setup.answers.j2
+++ b/templates/thinlinc-setup.answers.j2
@@ -6,7 +6,7 @@ setup-firewall=yes
 setup-selinux=yes
 setup-web-integration=yes
 setup-apparmor=yes
-{% if ansible_fqdn in groups['thinlinc-masters'] %}
+{% if ansible_fqdn in groups['thinlinc_masters'] %}
 server-type=master
 {% else %}
 server-type=agent


### PR DESCRIPTION
During execution of of the playbook ansible warns about not allowed dashes ("-") in the inventory file.
I have replaced dashes by underscores.