### PR TITLE
make xauthority location configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,8 @@ thinlinc_tlsetup_migrate_conf: "old"
 #
 # The default value is null, which is equal to ansible_fqdn.
 thinlinc_agent_hostname: null
+
+# The xauthority location for the user session.
+# Options: 'sessiondir' or 'homedir'
+# Default is sessiondir.
+thinlinc_xauthority_location: "sessiondir"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,3 +67,10 @@
     value: "{{ ' '.join(groups['thinlinc_agents']) or 'localhost' }}"
   notify: restart vsmserver
   when: "'thinlinc_masters' in group_names"
+
+- name: Set /vsmagent/xauthority_location
+  tlconfig:
+    param: /vsmagent/xauthority_location
+    value: "{{ thinlinc_xauthority_location }}"
+  notify: restart vsmagent
+  when: "'thinlinc_agents' in group_names"

--- a/templates/thinlinc-setup.answers.j2
+++ b/templates/thinlinc-setup.answers.j2
@@ -20,3 +20,4 @@ install-required-libs={{ thinlinc_autoinstall_dependencies }}
 setup-nearest={{ thinlinc_printers }}
 setup-thinlocal={{ thinlinc_printers }}
 tlwebadm-password={{ thinlinc_webadm_password }}
+xauthority_location={{ thinlinc_xauthority_location }}


### PR DESCRIPTION
It's Hacktoberfest and I would like to take this opportunity to work on improvements for this repository.

First PR is to make 'thinlinc_xauthority_location' configurable.
At work we use 'homedir' because of application issues with 'sessiondir'.