### PR TITLE
added thinlinc_server_bundle_location variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ thinlinc_accept_eula: "no"
 thinlinc_version: "4.12.0"
 thinlinc_build: "6517"
 thinlinc_server_bundle: "tl-4.12.0-server.zip"
-
+thinlinc_server_bundle_location: "{{ thinlinc_server_bundle }}"
 thinlinc_autoinstall_dependencies: "yes"
 
 thinlinc_email: "root@localhost"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
   block:
     - name: Unpacking ThinLinc server bundle
       unarchive:
-        src: "{{ thinlinc_server_bundle }}"
+        src: "{{ thinlinc_server_bundle_location }}"
         dest: /root
     - include_vars: "packages-rpm-{{ ansible_architecture }}.yml"
       when: ansible_os_family in ["RedHat", "Suse"]


### PR DESCRIPTION
Added a new variable which makes it possible to overide the location of the bundle file.
Today you have to put the bundel file in the playbook files directory. Using this variable you can put the file somewhere else.
The default value is to maintain compatibility with previous version of this playbook.

* default/main.yml

```yaml
thinlinc_server_bundle: "tl-4.12.0-server.zip"
thinlinc_server_bundle_location: "{{ thinlinc_server_bundle }}"
```

* tasks/main.yml

```yaml
 - name: Unpacking ThinLinc server bundle
      unarchive:
        src: "{{ thinlinc_server_bundle_location }}"
```


By overriding this variable, makes it easy to save your bundle file outside of this playbook, without changing to the original playbook.

```yaml
- name: Execute standard ansible-role-thinlinc-server
  include_role: 
    name: ansible-role-thinlinc-server
  vars:
    thinlinc_server_bundle_location: "/local/artifactory/tl-4.12.1-server.zip"
```

If this PR is inluded, my ansible-role-thinlinc-beta-server will also work :-)
https://github.com/pewo/ansible-role-thinlinc-beta-server


