### PR TITLE
Bumped version to 4.12.1 and modified install-thinlinc-debian/rhel/suse tasks to not use loop and not check for package signatures.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,9 @@
 
 thinlinc_accept_eula: "no"
 
-thinlinc_version: "4.12.0"
-thinlinc_build: "6517"
-thinlinc_server_bundle: "tl-4.12.0-server.zip"
+thinlinc_version: "4.12.1"
+thinlinc_build: "6733"
+thinlinc_server_bundle: "tl-4.12.1-server.zip"
 
 thinlinc_autoinstall_dependencies: "yes"
 

--- a/tasks/install-thinlinc-debian.yml
+++ b/tasks/install-thinlinc-debian.yml
@@ -7,5 +7,5 @@
 #  with_items: "{{ thinlinc_packages }}"
 
 - name: Install ThinLinc Software
-  command: "/usr/bin/dpkg --install {{ ' '.join(thinlinc_packages) }}"
+  command: "/usr/bin/dpkg --install --no-debsig {{ ' '.join(thinlinc_packages) }}"
   notify: run tl-setup

--- a/tasks/install-thinlinc-rhel.yml
+++ b/tasks/install-thinlinc-rhel.yml
@@ -1,5 +1,4 @@
 ---
 - name: Install ThinLinc Software
-  yum: name="{{ item }}" state=present
-  with_items: "{{ thinlinc_packages }}"
+  yum: name="{{ thinlinc_packages }}" state=present  disable_gpg_check=true
   notify: run tl-setup

--- a/tasks/install-thinlinc-suse.yml
+++ b/tasks/install-thinlinc-suse.yml
@@ -1,5 +1,4 @@
 ---
 - name: Install ThinLinc Software
-  zypper: name="{{ item }}" state=present disable_gpg_check=True
-  with_items: "{{ thinlinc_packages }}"
+  zypper: name="{{ thinlinc_packages }}" state=present disable_gpg_check=True
   notify: run tl-setup


### PR DESCRIPTION

Added --no-debsig to  install-thinlinc-debian.yml 
Added disable_gpg_check=true to  install-thinlinc-rhel.yml

Removed the loop in the installation tasks to remove the deprecation warning:

DEPRECATION WARNING]: Invoking "zypper" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and
specifying `name: "{{ item }}"`, please use `name: '{{ thinlinc_packages }}'` and remove the loop. This feature will be removed from ansible-base in version 2.11.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
