### PR TITLE
Added workaround for /usr/etc/pam.d/sshd

### DIFF
--- a/tasks/copy_usr_etc_pam_sshd.yml
+++ b/tasks/copy_usr_etc_pam_sshd.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Check /etc/pam.d/sshd
+  stat:
+    path: /etc/pam.d/sshd
+  register: etc_pam_sshd
+
+- block:
+
+    - name: Check /usr/etc/pam.d/sshd
+      stat:
+        path: /usr/etc/pam.d/sshd
+      register: usr_etc_pam_sshd
+
+    - name: Copy /usr/etc/pam.d/sshd to  /etc/pam.d/sshd
+      copy:
+        src: /usr/etc/pam.d/sshd
+        dest: /etc/pam.d/sshd
+        remote_src: true
+      when: usr_etc_pam_sshd.stat.exists == true
+
+  when: etc_pam_sshd.stat.exists == false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,8 @@
       when: ansible_os_family in ["Debian", "Ubuntu", "Linuxmint"]
   when: thinlinc_packages_installed.rc == 1
 
+- name: Copy /usr/etc/pam.d/sshd
+  include_tasks: "copy_usr_etc_pam_sshd.yml"
 
 - name: Copy in tlsetup.answers
   template:


### PR DESCRIPTION
Inserted a small fix to be able to install properly on openSUSE Tumbleweed.
This should probably be fixed by the thinlinc installer. 
On my installation the /etc/pam.d/sshd and /usr/etc/pam.d/sshd has the same content.