### PR TITLE
Prevent failure on empty inventory groups

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,13 +80,13 @@
 - name: Configure /vsmagent/allowed_clients
   tlconfig:
     param: /vsmagent/allowed_clients
-    value: "{{ groups['thinlinc_masters'] | default(['localhost']) | join(' ') }}"
+    value: "{{ groups['thinlinc_masters'] | default(['localhost'], true) | join(' ') }}"
   notify: restart vsmagent
   when: "'thinlinc_agents' in group_names"
 
 - name: Configure list of agent servers
   tlconfig:
     param: /vsmserver/subclusters/Default/agents
-    value: "{{ groups['thinlinc_agents'] | default(['localhost']) | join(' ') }}"
+    value: "{{ groups['thinlinc_agents'] | default(['localhost'], true) | join(' ') }}"
   notify: restart vsmserver
   when: "'thinlinc_masters' in group_names"


### PR DESCRIPTION
If role-defined groups exist in the inventory but are empty, execution fails. This patch ensures that the default value is used not only if the group is missing, but also if it exists and is empty.

Fixes #31.