### PR TITLE
Fix template logic

### DIFF
--- a/templates/thinlinc-setup.answers.j2
+++ b/templates/thinlinc-setup.answers.j2
@@ -6,7 +6,7 @@ setup-firewall=yes
 setup-selinux=yes
 setup-web-integration=yes
 setup-apparmor=yes
-{% if ('thinlinc_masters' not in group_names) or (ansible_facts['fqdn'] in groups['thinlinc_masters']) %}
+{% if 'thinlinc_masters' in group_names %}
 server-type=master
 {% else %}
 server-type=agent


### PR DESCRIPTION
Parameter 'server_type' should be 'master' if the host is in the group 'thinlinc_masters', but not otherwise. This patch prevents the parameter being set to 'master' even if the host is not in this group.

Fixes #33.