### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ requirements.yml` to install the role:
 - src: https:///github.com/cendio/ansible-role-thinlinc-server.git
   scm: git
   name: thinlinc-server
-  version: v1.1
+  version: v1.10
 ```
 
 The role uses three groups - thinlinc_masters, thinlinc_agents and
-thinlinc-servers. Here's an example inventory file with one master
+thinlinc_servers. Here's an example inventory file with one master
 server and three agent servers:
 
 ```yaml


### PR DESCRIPTION
There is a minor typo in one of the group names (hyphen instead of underscore). Also, the example given for installing the module references an old version number. This patch fixes the typo and bumps the version number up to latest.