### PR TITLE
Allow specifying bundle path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ thinlinc_version: "4.14.0"
 ThinLinc version number.
 
 ```yaml
+thinlinc_bundle_path: "tl-{{ thinlinc_version }}-server.zip"
+```
+
+The location of the ThinLinc Server Bundle to install. If not set, the
+default Ansible search paths and bundle filename will be used.
+
+```yaml
 thinlinc_autoinstall_dependencies: "yes"
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 thinlinc_accept_eula: "no"
 
 thinlinc_version: "4.17.0"
+thinlinc_bundle_path: "tl-{{ thinlinc_version }}-server.zip"
 
 thinlinc_autoinstall_dependencies: "yes"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   block:
     - name: Unpacking ThinLinc server bundle
       unarchive:
-        src: "tl-{{ thinlinc_version }}-server.zip"
+        src: "{{ thinlinc_bundle_path }}"
         dest: /root
         creates: "/root/tl-{{ thinlinc_version }}-server"
     - name: Run tasks for RHEL-like


### PR DESCRIPTION
In fad51d0 we removed the thinlinc_server_bundle parameter. This means that the bundle must be in a standard Ansible search path, using the standard bundle filename.

This commit re-implements a variation of this parameter, but makes it optional with sensible defaults. This makes it possible for people to use non-standard locations and filenames, but still keeps the intention of the original commit by only requiring the version to be specified in one place.

Fixes #42.