### PR TITLE
Minor fixes and bumbed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ThinLinc End User License Agreement. NOTE: Setting this to yes is a
 requirement for installing and using ThinLinc.
 
 ```yaml
-thinlinc_version: "4.14.0"
+thinlinc_version: "4.18.0"
 ```
 
 ThinLinc version number.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 thinlinc_accept_eula: "no"
 
-thinlinc_version: "4.17.0"
+thinlinc_version: "4.18.0"
 thinlinc_bundle_path: "tl-{{ thinlinc_version }}-server.zip"
 
 thinlinc_autoinstall_dependencies: "yes"

--- a/tasks/copy_usr_etc_pam_sshd.yml
+++ b/tasks/copy_usr_etc_pam_sshd.yml
@@ -9,16 +9,24 @@
     - name: Check /usr/etc/pam.d/sshd
       stat:
         path: /usr/etc/pam.d/sshd
-      register: usr_etc_pam_sshd
+      register: locate_pam_sshd
 
-    - name: Copy /usr/etc/pam.d/sshd to  /etc/pam.d/sshd
+    - name: Check /usr/lib/pam.d/sshd
+      stat:
+        path: /usr/lib/pam.d/sshd
+      register: locate_pam_sshd
+      when: locate_pam_sshd.stat.exists is defined
+            and not locate_pam_sshd.stat.exists
+
+    - name: Copy located pam.d/sshd to /etc/pam.d/sshd
       copy:
-        src: /usr/etc/pam.d/sshd
+        src: "{{ locate_pam_sshd.stat.path }}"
         dest: /etc/pam.d/sshd
         owner: root
         group: root
         mode: '0644'
         remote_src: true
-      when: usr_etc_pam_sshd.stat.exists == true
+      when: locate_pam_sshd.stat.exists is defined
+            and locate_pam_sshd.stat.exists == true
 
   when: etc_pam_sshd.stat.exists == false

--- a/tasks/install-thinlinc-suse.yml
+++ b/tasks/install-thinlinc-suse.yml
@@ -1,5 +1,4 @@
 ---
----
 - name: Locate 32-bit packages
   find:
     paths: "/root/tl-{{ thinlinc_version }}-server/packages"

--- a/templates/thinlinc-setup.answers.j2
+++ b/templates/thinlinc-setup.answers.j2
@@ -6,7 +6,6 @@ setup-firewall=yes
 setup-selinux=yes
 setup-web-integration=yes
 setup-apparmor=yes
-agent-hostname-choice=hostname
 {% if 'thinlinc_masters' in group_names %}
 server-type=master
 {% else %}

--- a/templates/thinlinc-setup.answers.j2
+++ b/templates/thinlinc-setup.answers.j2
@@ -6,6 +6,7 @@ setup-firewall=yes
 setup-selinux=yes
 setup-web-integration=yes
 setup-apparmor=yes
+agent-hostname-choice=hostname
 {% if 'thinlinc_masters' in group_names %}
 server-type=master
 {% else %}


### PR DESCRIPTION
Removed duplicate yaml  dockument start in install-thinlinc-suse.yml
Bumbed version to 4.18.0
Added agent-hostname-choice=hostname to thinlinc-setup.answers.j2
SUSE Tumbleweed moved pam configuration for sshd to /usr/lib/pam.d/sshd, thinlinc need this to be in /etc/pam.d/sshd. Extending this task to locate pam.d/sshd in /usr/etc/pam.d/sshd and /usr/lib/pam.d/sshd.