### PR TITLE
Update answers file with new responses

### DIFF
--- a/templates/thinlinc-setup.answers.j2
+++ b/templates/thinlinc-setup.answers.j2
@@ -20,3 +20,4 @@ install-required-libs={{ thinlinc_autoinstall_dependencies | ternary('yes', 'no'
 setup-nearest={{ thinlinc_printers | ternary('yes', 'no', 'no') }}
 setup-thinlocal={{ thinlinc_printers | ternary('yes', 'no', 'no') }}
 tlwebadm-password={{ thinlinc_webadm_password }}
+agent-hostname-choice=ip


### PR DESCRIPTION
A new response is required for tl-setup in ThinLinc 4.18.0, so add it to our answers file. Setting this to 'ip'  keeps the old default behaviour; we set the agent_hostname parameter later in the playbook anyway.