### PR TITLE
Bump version to 4.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.12] - 2025-01-07
+
+### Changed
+
  - Updated to 4.18.0
  - Updated tlsetup answers to match the 4.18.0 changes
 
@@ -113,7 +117,8 @@ First release.
 
 - An Ansible role to install the ThinLinc server software.
 
-[unreleased]: https://github.com/cendio/ansible-role-thinlinc-server/compare/v1.11...HEAD
+[unreleased]: https://github.com/cendio/ansible-role-thinlinc-server/compare/v1.12...HEAD
+[1.12]: https://github.com/cendio/ansible-role-thinlinc-server/compare/v1.11...v1.12
 [1.11]: https://github.com/cendio/ansible-role-thinlinc-server/compare/v1.10...v1.11
 [1.10]: https://github.com/cendio/ansible-role-thinlinc-server/compare/v1.9...v1.10
 [1.9]: https://github.com/cendio/ansible-role-thinlinc-server/compare/v1.8...v1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
  - Updated to 4.18.0
+ - Updated tlsetup answers to match the 4.18.0 changes
 
 ## [1.11] - 2024-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+ - Updated to 4.18.0
+
 ## [1.11] - 2024-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ThinLinc End User License Agreement. NOTE: Setting this to yes is a
 requirement for installing and using ThinLinc.
 
 ```yaml
-thinlinc_version: "4.14.0"
+thinlinc_version: "4.18.0"
 ```
 
 ThinLinc version number.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 thinlinc_accept_eula: "no"
 
-thinlinc_version: "4.17.0"
+thinlinc_version: "4.18.0"
 thinlinc_bundle_path: "tl-{{ thinlinc_version }}-server.zip"
 
 thinlinc_autoinstall_dependencies: "yes"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,9 @@ thinlinc_webadm_password: "$6$7cc31a35e02e55ec$hm.1MsloeBJqNKljx9RH88Z/eRKZCka5Z
 #  - parameters: auto-migrate old to new configuration
 thinlinc_tlsetup_migrate_conf: "old"
 
+thinlinc_hostname_choice: "ip"
+thinlinc_manual_agent_hostname: ""
+
 
 # The agent hostname to report to clients. If your server is behind a
 # firewall with NAT, this must be set to an address that forwards to

--- a/templates/thinlinc-setup.answers.j2
+++ b/templates/thinlinc-setup.answers.j2
@@ -2,6 +2,8 @@
 install-gtk={{ thinlinc_autoinstall_dependencies | ternary('yes', 'no', 'no') }}
 email-address={{ thinlinc_email }}
 install-python-ldap={{ thinlinc_autoinstall_dependencies | ternary('yes', 'no', 'no') }}
+agent-hostname-choice={{ thinlinc_hostname_choice }}
+manual-agent-hostname={{ thinlinc_manual_agent_hostname }}
 setup-firewall=yes
 setup-selinux=yes
 setup-web-integration=yes


### PR DESCRIPTION
This is related to #45 #46, but we need to merge this promptly as we are in the process of upgrading our internal systems. 
