### PR TITLE
Fixed opensuse installation issuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update SUSE usr merge workaround to match SLES 16 changes
+
 ## [1.13] - 2025-07-09
 
 ### Changed

--- a/tasks/copy_usr_etc_pam_sshd.yml
+++ b/tasks/copy_usr_etc_pam_sshd.yml
@@ -9,16 +9,24 @@
     - name: Check /usr/etc/pam.d/sshd
       stat:
         path: /usr/etc/pam.d/sshd
-      register: usr_etc_pam_sshd
+      register: locate_pam_sshd
 
-    - name: Copy /usr/etc/pam.d/sshd to  /etc/pam.d/sshd
+    - name: Check /usr/lib/pam.d/sshd
+      stat:
+        path: /usr/lib/pam.d/sshd
+      register: locate_pam_sshd
+      when: locate_pam_sshd.stat.exists is defined
+            and not locate_pam_sshd.stat.exists
+
+    - name: Copy located pam.d/sshd to /etc/pam.d/sshd
       copy:
-        src: /usr/etc/pam.d/sshd
+        src: "{{ locate_pam_sshd.stat.path }}"
         dest: /etc/pam.d/sshd
         owner: root
         group: root
         mode: '0644'
         remote_src: true
-      when: usr_etc_pam_sshd.stat.exists == true
+      when: locate_pam_sshd.stat.exists is defined
+            and locate_pam_sshd.stat.exists == true
 
   when: etc_pam_sshd.stat.exists == false

--- a/tasks/install-thinlinc-suse.yml
+++ b/tasks/install-thinlinc-suse.yml
@@ -1,5 +1,4 @@
 ---
----
 - name: Locate 32-bit packages
   find:
     paths: "/root/tl-{{ thinlinc_version }}-server/packages"


### PR DESCRIPTION
In my lack of git experience, I deleted my fork and made a new one.

Reworked only the SUSE changes.

Removed duplicate yaml dockument start in install-thinlinc-suse.yml

SUSE Tumbleweed moved pam configuration for sshd to /usr/lib/pam.d/sshd, thinlinc need this to be in /etc/pam.d/sshd. Extending this task to locate pam.d/sshd in /usr/etc/pam.d/sshd and /usr/lib/pam.d/sshd.
