### PR TITLE
Remove support for 32-bit packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Removed
+
+- Support for 32-bit server packages
+
 ## [1.13] - 2025-07-09
 
 ### Changed

--- a/tasks/install-thinlinc-debian.yml
+++ b/tasks/install-thinlinc-debian.yml
@@ -1,44 +1,22 @@
 ---
-- name: Locate 32-bit packages
-  find:
-    paths: "/root/tl-{{ thinlinc_version }}-server/packages"
-    patterns:
-      - "thinlinc*i386.deb"
-      - "thinlinc*all.deb"
-  when: ansible_architecture == 'i386'
-  register: _packages_32bit
-
-- name: Locate 64-bit packages
+- name: Locate server packages
   find:
     paths: "/root/tl-{{ thinlinc_version }}-server/packages"
     patterns:
       - "thinlinc*amd64.deb"
       - "thinlinc*all.deb"
-  when: ansible_architecture == 'x86_64'
-  register: _packages_64bit
+  register: _packages
 
 # The apt provider actually calls dpkg for local packages, which isn't
 # clever enough to handle our upgrades:
 # https://github.com/ansible/ansible/issues/77150
 #
-- name: Install 32-bit ThinLinc Software
-  command: >
-    /usr/bin/apt-get install -y
-    -o Dpkg::Options::="--no-debsig"
-    -o Dpkg::Options::="--force-confold"
-    {{ _packages_32bit.files | map(attribute='path') | join(' ') }}
-  environment:
-    DEBIAN_FRONTEND: noninteractive
-  when: _packages_32bit is not skipped
-  notify: run tl-setup
-
-- name: Install 64-bit ThinLinc Software
+- name: Install ThinLinc Software
   command: >
       /usr/bin/apt-get install -y
       -o Dpkg::Options::="--no-debsig"
       -o Dpkg::Options::="--force-confold"
-      {{ _packages_64bit.files | map(attribute='path') | join(' ') }}
+      {{ _packages.files | map(attribute='path') | join(' ') }}
   environment:
     DEBIAN_FRONTEND: noninteractive
-  when: _packages_64bit is not skipped
   notify: run tl-setup

--- a/tasks/install-thinlinc-rhel.yml
+++ b/tasks/install-thinlinc-rhel.yml
@@ -1,34 +1,15 @@
 ---
-- name: Locate 32-bit packages
-  find:
-    paths: "/root/tl-{{ thinlinc_version }}-server/packages"
-    patterns:
-      - "thinlinc*i686.rpm"
-      - "thinlinc*noarch.rpm"
-  when: ansible_architecture == 'i386'
-  register: _packages_32bit
-
-- name: Locate 64-bit packages
+- name: Locate server packages
   find:
     paths: "/root/tl-{{ thinlinc_version }}-server/packages"
     patterns:
       - "thinlinc*x86_64.rpm"
       - "thinlinc*noarch.rpm"
-  when: ansible_architecture == 'x86_64'
-  register: _packages_64bit
+  register: _packages
 
-- name: Install 32-bit ThinLinc Software
+- name: Install ThinLinc Software
   yum:
-    name: "{{ _packages_32bit.files | map(attribute='path') | list }}"
+    name: "{{ _packages.files | map(attribute='path') | list }}"
     state: present
     disable_gpg_check: true
-  when: _packages_32bit is not skipped
-  notify: run tl-setup
-
-- name: Install 64-bit ThinLinc Software
-  yum:
-    name: "{{ _packages_64bit.files | map(attribute='path') | list }}"
-    state: present
-    disable_gpg_check: true
-  when: _packages_64bit is not skipped
   notify: run tl-setup

--- a/tasks/install-thinlinc-suse.yml
+++ b/tasks/install-thinlinc-suse.yml
@@ -1,35 +1,15 @@
 ---
----
-- name: Locate 32-bit packages
-  find:
-    paths: "/root/tl-{{ thinlinc_version }}-server/packages"
-    patterns:
-      - "thinlinc*i686.rpm"
-      - "thinlinc*noarch.rpm"
-  when: ansible_architecture == 'i386'
-  register: _packages_32bit
-
-- name: Locate 64-bit packages
+- name: Locate server packages
   find:
     paths: "/root/tl-{{ thinlinc_version }}-server/packages"
     patterns:
       - "thinlinc*x86_64.rpm"
       - "thinlinc*noarch.rpm"
-  when: ansible_architecture == 'x86_64'
-  register: _packages_64bit
+  register: _packages
 
-- name: Install 32-bit ThinLinc Software
+- name: Install ThinLinc Software
   zypper:
-    name: "{{ _packages_32bit.files | map(attribute='path') | list }}"
+    name: "{{ _packages.files | map(attribute='path') | list }}"
     state: present
     disable_gpg_check: true
-  when: _packages_32bit is not skipped
-  notify: run tl-setup
-
-- name: Install 64-bit ThinLinc Software
-  zypper:
-    name: "{{ _packages_64bit.files | map(attribute='path') | list }}"
-    state: present
-    disable_gpg_check: true
-  when: _packages_64bit is not skipped
   notify: run tl-setup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Ensure architecture is supported by current version
-  assert:
-    that: thinlinc_version is version('4.14.0', '<=')
-    msg: "32-bit architecture not supported by this version"
-  when: ansible_architecture == 'i386'
-
 - name: Installing pre-requisites
   package:
     name: unzip


### PR DESCRIPTION
We don't ship 32-bit packages in any supported version of ThinLinc anymore, so we can remove the code for dealing with them.

Fixes #52.