### PR TITLE
Make the role compatible with ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+---
+profile: production

--- a/.yamllint
+++ b/.yamllint
@@ -3,6 +3,11 @@ extends: default
 
 rules:
   line-length: disable
-
-  truthy:
-    allowed-values: ['true', 'True', 'yes', 'false', 'False', 'no']
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Role Variables
 --------------
 
 ```yaml
-thinlinc_accept_eula: "no"
+thinlinc_accept_eula: false
 ```
 
 By changing this to "yes", you agree to the terms specified in the
@@ -49,7 +49,7 @@ The location of the ThinLinc Server Bundle to install. If not set, the
 default Ansible search paths and bundle filename will be used.
 
 ```yaml
-thinlinc_autoinstall_dependencies: "yes"
+thinlinc_autoinstall_dependencies: true
 ```
 
 When set to "yes", this will automatically install any required
@@ -64,7 +64,7 @@ thinlinc_emails:
 A list of administrative email addresses to receive license warnings.
 
 ```yaml
-thinlinc_printers: "yes"
+thinlinc_printers: true
 ```
 
 Whether to install the optional CUPS printer queues for ThinLinc.
@@ -148,13 +148,14 @@ thinlinc_agents
 ```
 
 Now that we got both a role and an inventory, connect the dots by
-applying the thinlinc-server role to the thinlinc_servers group with a
+applying the thinlinc_server role to the thinlinc_servers group with a
 `thinlinc.yml` playbook:
 
 ```yaml
 - hosts: thinlinc_servers
   roles:
-    - { role: thinlinc_server, thinlinc_accept_eula: "yes" }
+    - role: thinlinc_server
+      thinlinc_accept_eula: true
 ```
 
 The final step is to apply the playbook to the inventory, like this:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ requirements.yml` to install the role:
 ---
 - src: https:///github.com/cendio/ansible-role-thinlinc-server.git
   scm: git
-  name: thinlinc-server
+  name: thinlinc_server
   version: v1.10
 ```
 
@@ -154,7 +154,7 @@ applying the thinlinc-server role to the thinlinc_servers group with a
 ```yaml
 - hosts: thinlinc_servers
   roles:
-    - { role: thinlinc-server, thinlinc_accept_eula: "yes" }
+    - { role: thinlinc_server, thinlinc_accept_eula: "yes" }
 ```
 
 The final step is to apply the playbook to the inventory, like this:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# defaults file for thinlinc-server
+# defaults file for thinlinc_server
 
 thinlinc_accept_eula: "no"
 
@@ -32,7 +32,6 @@ thinlinc_tlsetup_migrate_conf: "old"
 
 thinlinc_hostname_choice: "ip"
 thinlinc_manual_agent_hostname: ""
-
 
 # The agent hostname to report to clients. If your server is behind a
 # firewall with NAT, this must be set to an address that forwards to

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,15 +1,15 @@
 ---
 # defaults file for thinlinc_server
 
-thinlinc_accept_eula: "no"
+thinlinc_accept_eula: false
 
 thinlinc_version: "4.20.1"
 thinlinc_bundle_path: "tl-{{ thinlinc_version }}-server.zip"
 
-thinlinc_autoinstall_dependencies: "yes"
+thinlinc_autoinstall_dependencies: true
 
 thinlinc_email: "root@localhost"
-thinlinc_printers: "yes"
+thinlinc_printers: true
 
 # The port on which the tlwebaccess service should listen
 thinlinc_webaccess_port: 300

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,5 +20,6 @@
     name: tlwebaccess
     state: restarted
 
+# Sometimes we need to force a rerun of the setup, therefore this command must run every time.
 - name: Run tl-setup
-  ansible.builtin.command: /opt/thinlinc/sbin/tl-setup -a "/root/thinlinc-setup.answers"
+  ansible.builtin.command: /opt/thinlinc/sbin/tl-setup -a "/root/thinlinc-setup.answers" # noqa: no-changed-when

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,24 +1,24 @@
 ---
-# handlers file for thinlinc-server
-- name: restart vsmagent
-  service:
+# handlers file for thinlinc_server
+- name: Restart vsmagent
+  ansible.builtin.service:
     name: vsmagent
     state: restarted
 
-- name: restart vsmserver
-  service:
+- name: Restart vsmserver
+  ansible.builtin.service:
     name: vsmserver
     state: restarted
 
-- name: restart tlwebadm
-  service:
+- name: Restart tlwebadm
+  ansible.builtin.service:
     name: tlwebadm
     state: restarted
 
-- name: restart tlwebaccess
-  service:
+- name: Restart tlwebaccess
+  ansible.builtin.service:
     name: tlwebaccess
     state: restarted
 
-- name: run tl-setup
-  command: /opt/thinlinc/sbin/tl-setup -a "/root/thinlinc-setup.answers"
+- name: Run tl-setup
+  ansible.builtin.command: /opt/thinlinc/sbin/tl-setup -a "/root/thinlinc-setup.answers"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   namespace: cendio
   role_name: thinlinc_server
 
-  min_ansible_version: 2.0
+  min_ansible_version: "2.0"
   # min_ansible_container_version:
   # github_branch:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,6 +4,8 @@ galaxy_info:
   description: Thinlinc Server
   company: Cendio AB
   license: GPLv3
+  namespace: cendio
+  role_name: thinlinc_server
 
   min_ansible_version: 2.0
   # min_ansible_container_version:
@@ -25,7 +27,5 @@ galaxy_info:
       versions:
         - bionic
 
-
   galaxy_tags: []
-
 dependencies: []

--- a/tasks/copy_usr_etc_pam_sshd.yml
+++ b/tasks/copy_usr_etc_pam_sshd.yml
@@ -1,32 +1,28 @@
 ---
-
 - name: Check /etc/pam.d/sshd
-  stat:
+  ansible.builtin.stat:
     path: /etc/pam.d/sshd
   register: etc_pam_sshd
 
-- block:
+- when: etc_pam_sshd.stat.exists == false
+  block:
     - name: Check /usr/etc/pam.d/sshd
-      stat:
+      ansible.builtin.stat:
         path: /usr/etc/pam.d/sshd
       register: locate_pam_sshd
 
     - name: Check /usr/lib/pam.d/sshd
-      stat:
+      ansible.builtin.stat:
         path: /usr/lib/pam.d/sshd
       register: locate_pam_sshd
-      when: locate_pam_sshd.stat.exists is defined
-            and not locate_pam_sshd.stat.exists
+      when: locate_pam_sshd.stat.exists is defined and not locate_pam_sshd.stat.exists
 
     - name: Copy located pam.d/sshd to /etc/pam.d/sshd
-      copy:
+      ansible.builtin.copy:
         src: "{{ locate_pam_sshd.stat.path }}"
         dest: /etc/pam.d/sshd
         owner: root
         group: root
-        mode: '0644'
+        mode: "0644"
         remote_src: true
-      when: locate_pam_sshd.stat.exists is defined
-            and locate_pam_sshd.stat.exists == true
-
-  when: etc_pam_sshd.stat.exists == false
+      when: locate_pam_sshd.stat.exists is defined and locate_pam_sshd.stat.exists == true

--- a/tasks/copy_usr_etc_pam_sshd.yml
+++ b/tasks/copy_usr_etc_pam_sshd.yml
@@ -4,7 +4,8 @@
     path: /etc/pam.d/sshd
   register: etc_pam_sshd
 
-- when: etc_pam_sshd.stat.exists == false
+- name: Copy to correct location
+  when: not etc_pam_sshd.stat.exists
   block:
     - name: Check /usr/etc/pam.d/sshd
       ansible.builtin.stat:
@@ -15,7 +16,9 @@
       ansible.builtin.stat:
         path: /usr/lib/pam.d/sshd
       register: locate_pam_sshd
-      when: locate_pam_sshd.stat.exists is defined and not locate_pam_sshd.stat.exists
+      when:
+        - locate_pam_sshd.stat.exists is defined
+        - not locate_pam_sshd.stat.exists
 
     - name: Copy located pam.d/sshd to /etc/pam.d/sshd
       ansible.builtin.copy:
@@ -25,4 +28,6 @@
         group: root
         mode: "0644"
         remote_src: true
-      when: locate_pam_sshd.stat.exists is defined and locate_pam_sshd.stat.exists == true
+      when:
+        - locate_pam_sshd.stat.exists is defined
+        - locate_pam_sshd.stat.exists is true

--- a/tasks/install-thinlinc-debian.yml
+++ b/tasks/install-thinlinc-debian.yml
@@ -11,7 +11,7 @@
 # clever enough to handle our upgrades:
 # https://github.com/ansible/ansible/issues/77150
 #
-- name: Install ThinLinc Software
+- name: Install ThinLinc Software # noqa: command-instead-of-module no-changed-when
   ansible.builtin.command: >
     /usr/bin/apt-get install -y
     -o Dpkg::Options::="--no-debsig"

--- a/tasks/install-thinlinc-debian.yml
+++ b/tasks/install-thinlinc-debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Locate server packages
-  find:
+  ansible.builtin.find:
     paths: "/root/tl-{{ thinlinc_version }}-server/packages"
     patterns:
       - "thinlinc*amd64.deb"
@@ -12,11 +12,11 @@
 # https://github.com/ansible/ansible/issues/77150
 #
 - name: Install ThinLinc Software
-  command: >
-      /usr/bin/apt-get install -y
-      -o Dpkg::Options::="--no-debsig"
-      -o Dpkg::Options::="--force-confold"
-      {{ _packages.files | map(attribute='path') | join(' ') }}
+  ansible.builtin.command: >
+    /usr/bin/apt-get install -y
+    -o Dpkg::Options::="--no-debsig"
+    -o Dpkg::Options::="--force-confold"
+    {{ _packages.files | map(attribute='path') | join(' ') }}
   environment:
     DEBIAN_FRONTEND: noninteractive
   notify: run tl-setup

--- a/tasks/install-thinlinc-rhel.yml
+++ b/tasks/install-thinlinc-rhel.yml
@@ -1,6 +1,6 @@
 ---
 - name: Locate server packages
-  find:
+  ansible.builtin.find:
     paths: "/root/tl-{{ thinlinc_version }}-server/packages"
     patterns:
       - "thinlinc*x86_64.rpm"
@@ -8,7 +8,7 @@
   register: _packages
 
 - name: Install ThinLinc Software
-  yum:
+  ansible.builtin.dnf:
     name: "{{ _packages.files | map(attribute='path') | list }}"
     state: present
     disable_gpg_check: true

--- a/tasks/install-thinlinc-suse.yml
+++ b/tasks/install-thinlinc-suse.yml
@@ -1,6 +1,6 @@
 ---
 - name: Locate server packages
-  find:
+  ansible.builtin.find:
     paths: "/root/tl-{{ thinlinc_version }}-server/packages"
     patterns:
       - "thinlinc*x86_64.rpm"
@@ -8,7 +8,7 @@
   register: _packages
 
 - name: Install ThinLinc Software
-  zypper:
+  community.general.zypper:
     name: "{{ _packages.files | map(attribute='path') | list }}"
     state: present
     disable_gpg_check: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,29 +1,14 @@
 ---
 - name: Installing pre-requisites
-  package:
+  ansible.builtin.package:
     name: unzip
     state: present
     update_cache: true
 
 - name: Collect installed packages
-  package_facts:
+  ansible.builtin.package_facts:
 
 - name: Installing ThinLinc packages
-  block:
-    - name: Unpacking ThinLinc server bundle
-      unarchive:
-        src: "{{ thinlinc_bundle_path }}"
-        dest: /root
-        creates: "/root/tl-{{ thinlinc_version }}-server"
-    - name: Run tasks for RHEL-like
-      include_tasks: "install-thinlinc-rhel.yml"
-      when: ansible_facts['os_family'] == "RedHat"
-    - name: Run tasks for SUSE-like
-      include_tasks: "install-thinlinc-suse.yml"
-      when: ansible_facts['os_family'] == "Suse"
-    - name: Run tasks for Debian-like
-      include_tasks: "install-thinlinc-debian.yml"
-      when: ansible_facts['os_family'] in ["Debian", "Ubuntu", "Linuxmint"]
   when: >
     (('thinlinc-server' not in ansible_facts['packages']) or
      (ansible_facts['packages']['thinlinc-server'][0]['version'].split('-') | first != thinlinc_version))
@@ -31,24 +16,38 @@
     (('thinlinc-vsm' not in ansible_facts['packages']) or
      (ansible_facts['packages']['thinlinc-vsm'][0]['version'].split('-') | first != thinlinc_version))
 
-# Workaround for OpenSUSE Tumbleweed usr merge
-# See https://www.cendio.com/bugzilla/show_bug.cgi?id=7829
+  # Workaround for OpenSUSE Tumbleweed usr merge
+  # See https://www.cendio.com/bugzilla/show_bug.cgi?id=7829
+  block:
+    - name: Unpacking ThinLinc server bundle
+      ansible.builtin.unarchive:
+        src: "{{ thinlinc_bundle_path }}"
+        dest: /root
+        creates: "/root/tl-{{ thinlinc_version }}-server"
+    - name: Run tasks for RHEL-like
+      ansible.builtin.include_tasks: "install-thinlinc-rhel.yml"
+      when: ansible_facts['os_family'] == "RedHat"
+    - name: Run tasks for SUSE-like
+      ansible.builtin.include_tasks: "install-thinlinc-suse.yml"
+      when: ansible_facts['os_family'] == "Suse"
+    - name: Run tasks for Debian-like
+      ansible.builtin.include_tasks: "install-thinlinc-debian.yml"
+      when: ansible_facts['os_family'] in ["Debian", "Ubuntu", "Linuxmint"]
 - name: Copy /usr/etc/pam.d/sshd
-  include_tasks: "copy_usr_etc_pam_sshd.yml"
+  ansible.builtin.include_tasks: "copy_usr_etc_pam_sshd.yml"
   when: ansible_facts['os_family'] == "Suse"
 
 - name: Copy in tlsetup.answers
-  template:
+  ansible.builtin.template:
     src: thinlinc-setup.answers.j2
     dest: /root/thinlinc-setup.answers
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   notify: run tl-setup
 
 - name: Force tl-setup to run if required
-  meta: flush_handlers
-
+  ansible.builtin.meta: flush_handlers
 - name: Configure /vsmagent/agent_hostname
   tlconfig:
     param: /vsmagent/agent_hostname

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - thinlinc-server
+    - thinlinc_server


### PR DESCRIPTION
Thanks to all of the cendio team for developing this role.

Best practice code style has evolved, this PR intends to bring it up to current ansible-lint standards.

This introduces a backwards-incompatible change: due to [the galaxy namespace constraints](https://old-galaxy.ansible.com/docs/contributing/namespaces.html#namespace-limitations), the role name has to be renamed from `thinlinc-server` to `thinlinc_server`. While this change is necessary to satisfy ansible-lint, the naming conventions are imposed by ansible itself and should be observed either way.